### PR TITLE
Attempt to add serde support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ repository = "https://github.com/mcy/byteyarn"
 keywords = ["string", "text", "binary"]
 
 license = "Apache-2.0"
+
+[dependencies]
+serde = { version = "1.0", optional = true }

--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -622,6 +622,52 @@ impl YarnBox<'_, str> {
   }
 }
 
+#[cfg(feature = "serde")]
+impl serde::Serialize for YarnBox<'_, str> {
+  #[inline]
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: serde::Serializer,
+  {
+    serializer.serialize_str(self.as_str())
+  }
+}
+
+#[cfg(feature = "serde")]
+impl<'de: 's, 's> serde::Deserialize<'de> for YarnBox<'s, str> {
+  fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+  where
+    D: serde::Deserializer<'de>,
+  {
+    let s: &'s str = serde::Deserialize::deserialize(deserializer)?;
+    let s = YarnBox::inlined(s).unwrap_or_else(|| YarnBox::new(s));
+    Ok(s)
+  }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for YarnBox<'_, [u8]> {
+  #[inline]
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: serde::Serializer,
+  {
+    serializer.serialize_bytes(self.as_bytes())
+  }
+}
+
+#[cfg(feature = "serde")]
+impl<'de: 's, 's> serde::Deserialize<'de> for YarnBox<'s, [u8]> {
+  fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+  where
+    D: serde::Deserializer<'de>,
+  {
+    let s: &'s [u8] = serde::Deserialize::deserialize(deserializer)?;
+    let s = YarnBox::inlined(s).unwrap_or_else(|| YarnBox::new(s));
+    Ok(s)
+  }
+}
+
 impl<Buf> Deref for YarnBox<'_, Buf>
 where
   Buf: crate::Buf + ?Sized,

--- a/src/reffed.rs
+++ b/src/reffed.rs
@@ -313,6 +313,52 @@ impl<'a> YarnRef<'a, str> {
   }
 }
 
+#[cfg(feature = "serde")]
+impl<'s> serde::Serialize for YarnRef<'s, str> {
+  #[inline]
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: serde::Serializer,
+  {
+    serializer.serialize_str(self.as_str())
+  }
+}
+
+#[cfg(feature = "serde")]
+impl<'s> serde::Serialize for YarnRef<'s, [u8]> {
+  #[inline]
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: serde::Serializer,
+  {
+    serializer.serialize_bytes(self.as_bytes())
+  }
+}
+
+#[cfg(feature = "serde")]
+impl<'de: 's, 's> serde::Deserialize<'de> for YarnRef<'s, str> {
+  fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+  where
+    D: serde::Deserializer<'de>,
+  {
+    let s: &'s str = serde::Deserialize::deserialize(deserializer)?;
+    let s = YarnRef::inlined(s).unwrap_or_else(|| YarnRef::new(s));
+    Ok(s)
+  }
+}
+
+#[cfg(feature = "serde")]
+impl<'de: 's, 's> serde::Deserialize<'de> for YarnRef<'s, [u8]> {
+  fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+  where
+    D: serde::Deserializer<'de>,
+  {
+    let s: &'s [u8] = serde::Deserialize::deserialize(deserializer)?;
+    let s = YarnRef::inlined(s).unwrap_or_else(|| YarnRef::new(s));
+    Ok(s)
+  }
+}
+
 impl<Buf> Deref for YarnRef<'_, Buf>
 where
   Buf: crate::Buf + ?Sized,


### PR DESCRIPTION
I saw #1 and I was interested in giving it a try. I modeled my attempt off of what kstring does https://github.com/search?q=repo%3Acobalt-org%2Fkstring%20serde&type=code . I've feature flagged off all of this behind a `serde` feature so it should be minimally invasive.

Is this is of interest, let me know what can be improved. In particular I wasn't sure what the right alternative to something like `YarnBox::inlined(s).unwrap_or_else(|| YarnBox::new(s))` was.

