### PR TITLE
Add FromStr impl for Yarn

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,5 +1,7 @@
 use std::borrow::Borrow;
+use std::convert::Infallible;
 use std::fmt;
+use std::str::FromStr;
 use std::str::Utf8Error;
 
 use crate::YarnBox;
@@ -206,6 +208,14 @@ impl From<YarnBox<'_, str>> for String {
 impl From<YarnRef<'_, str>> for String {
   fn from(y: YarnRef<str>) -> Self {
     y.to_string()
+  }
+}
+
+impl FromStr for YarnBox<'static, str> {
+  type Err = Infallible;
+
+  fn from_str(s: &str) -> Result<Self, Self::Err> {
+    Ok(Self::copy(s))
   }
 }
 


### PR DESCRIPTION
This is intended to be akin to the `FromStr` implementation for `String` [found in `std::string`](https://doc.rust-lang.org/src/alloc/string.rs.html#2407-2413).